### PR TITLE
Create _Directorys const

### DIFF
--- a/bin/lib/download/download.js
+++ b/bin/lib/download/download.js
@@ -2,6 +2,7 @@ const path = require('path');
 const spawn = require('cross-spawn');
 const fs = require('fs-extra');
 const { spawnCallback, handleError } = require('../utils/_logUtils');
+const _Directorys = require('../utils/_directorys');
 
 module.exports = downloadThemeFiles = async () => {
   try {


### PR DESCRIPTION
@ZacarieCarr 

Was getting an error when running `mango download`...

```
ReferenceError: _Directorys is not defined
    at downloadThemeFiles (/usr/local/lib/node_modules/@shopackify/mango/bin/lib/download/download.js:11:27)
```

![https://screenshot.click/02-35-sh8p8-cc6gr.png](https://screenshot.click/02-35-sh8p8-cc6gr.png)

Defining this const seems to fix it.